### PR TITLE
Remove SAP from header bio and update tools list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -108,7 +108,7 @@ analytics:
 author:
   name             : "JJ Gong"
   avatar           : "https://avatars3.githubusercontent.com/u/29085635?s=400&u=d711d1e7ac6007b219e9c9e621f4cf56b4f00458&v=4"
-  bio              : "Senior Machine Learning Engineer at SAP"
+  bio              : "Senior Machine Learning Engineer"
   location         : "New York City"
   email            :
   links:

--- a/_pages/resume.md
+++ b/_pages/resume.md
@@ -28,7 +28,7 @@ author_profile: true
 
 **Languages:** Python, SQL, NoSQL
 
-**Tools & Platforms:** AWS, Jupyter Notebooks
+**Tools & Platforms:** AWS, Azure, Postgres, MongoDB, Claude Code
 
 ---
 


### PR DESCRIPTION
- Remove "at SAP" from the author bio in _config.yml
- Update Tools & Platforms in resume to: AWS, Azure, Postgres, MongoDB, Claude Code

https://claude.ai/code/session_01GF2WmsGwEpx2za1WoDkw5N